### PR TITLE
Support WaterdogPE 2.0 (and partial bungee updates)

### DIFF
--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -20,6 +20,10 @@
             <id>sonatype-nexus-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>bungeecord-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -30,9 +34,17 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>network.ycc.waterdog</groupId>
-            <artifactId>waterdog-api</artifactId>
-            <version>1.15-SNAPSHOT</version>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
+            <type>javadoc</type>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bungeecord/src/main/java/alemiz/stargate/handler/PacketHandler.java
+++ b/bungeecord/src/main/java/alemiz/stargate/handler/PacketHandler.java
@@ -50,7 +50,7 @@ public class PacketHandler extends ConnectedHandler {
                 response.getPlayerList().add(player.getName());
             }
 
-            for (ServerInfo serverInfo : this.loader.getProxy().getServersCopy().values()){
+            for (ServerInfo serverInfo : this.loader.getProxy().getServers().values()){
                 response.getServerList().add(serverInfo.getName());
             }
             this.session.sendPacket(response);
@@ -115,9 +115,7 @@ public class PacketHandler extends ConnectedHandler {
                 packet.getServerName(),
                 packet.getAddress(),
                 "",
-                false,
-                packet.getServerType().equals("bedrock"),
-                "default"
+                false
         );
         this.loader.getProxy().getServers().put(packet.getServerName(), serverInfo);
         return true;

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>stargate</artifactId>
         <groupId>alemiz.stargate</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.26</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>alemiz.stargate</groupId>
     <artifactId>stargate</artifactId>
     <packaging>pom</packaging>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
 
     <modules>
         <module>server</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>stargate</artifactId>
         <groupId>alemiz.stargate</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.26</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/waterdogpe/pom.xml
+++ b/waterdogpe/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>stargate</artifactId>
         <groupId>alemiz.stargate</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,8 +13,16 @@
 
     <repositories>
         <repository>
-            <id>waterdog-repo</id>
-            <url>https://repo.waterdog.dev/artifactory/main</url>
+            <id>nukkitx-repo-release</id>
+            <url>https://repo.opencollab.dev/maven-releases/</url>
+        </repository>
+        <repository>
+            <id>nukkitx-repo-snapshot</id>
+            <url>https://repo.opencollab.dev/maven-snapshots/</url>
+        </repository>
+        <repository>
+            <id>waterdog</id>
+            <url>https://repo.waterdog.dev/artifactory/main/</url>
         </repository>
     </repositories>
 
@@ -28,7 +36,7 @@
         <dependency>
             <groupId>dev.waterdog.waterdogpe</groupId>
             <artifactId>waterdog</artifactId>
-            <version>1.1.10-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/waterdogpe/src/main/java/alemiz/stargate/handler/PacketHandler.java
+++ b/waterdogpe/src/main/java/alemiz/stargate/handler/PacketHandler.java
@@ -19,9 +19,9 @@ import alemiz.stargate.StarGate;
 import alemiz.stargate.protocol.*;
 import alemiz.stargate.server.ServerSession;
 import alemiz.stargate.server.handler.ConnectedHandler;
+import dev.waterdog.waterdogpe.network.connection.client.ClientConnection;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfoType;
-import dev.waterdog.waterdogpe.network.session.DownstreamClient;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 
 public class PacketHandler extends ConnectedHandler {
@@ -98,9 +98,9 @@ public class PacketHandler extends ConnectedHandler {
         response.setResponseId(packet.getResponseId());
         response.setUpstreamPing(player.getPing());
 
-        DownstreamClient downstream = player.getDownstream();
+        ClientConnection downstream = player.getDownstreamConnection();
         if (downstream != null && downstream.isConnected()) {
-            response.setDownstreamPing(downstream.getSession().getLatency());
+            response.setDownstreamPing(downstream.getPing());
         }
         this.session.sendPacket(response);
         return true;
@@ -112,7 +112,10 @@ public class PacketHandler extends ConnectedHandler {
             return this.loader.getProxy().removeServerInfo(packet.getServerName()) != null;
         }
 
-        ServerInfoType serverType = ServerInfoType.getOrBedrock(packet.getServerType());
+        ServerInfoType serverType = ServerInfoType.fromString(packet.getServerType());
+        if (serverType == null) {
+            serverType = ServerInfoType.BEDROCK;
+        }
         ServerInfo serverInfo = this.loader.getProxy().getServerInfoMap().createServerInfo(
                 packet.getServerName(), packet.getAddress(), packet.getPublicAddress(), serverType);
         return this.loader.getProxy().registerServerInfo(serverInfo);


### PR DESCRIPTION
# Description
This update adds support for WaterdogPE v2. (and updated bungeecord)

Not sure if bungeecord works, but I needed to make changes to this in order to build the project.

# Changes
* Bumped lombok to 2.18.4 to 2.18.26
* stargate-waterdog now supports WDPE v2
* Bungeecord has been updated to support Minecraft: Java Edition 1.19.x 