### PR TITLE
Changing Netty IO Version Cause Of Many Problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.43.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <fastutil.version>8.4.2</fastutil.version>
     </properties>
 


### PR DESCRIPTION
After The New Update Of WaterDogPE And Changing the Version of Netty, Many Problems Started To appear, The Custom StarGate Packets That was working started to broke, sending "unknown packet" even they registered and was working before the update, and many problems , Error In Decoding StarGate Packet, Errors That Should Be Discovered By The Development Team.